### PR TITLE
Vibration as Unity git-package

### DIFF
--- a/Example.meta
+++ b/Example.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: f8faa38587bfb4cc3b4e1fa6631a2f67
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,19 @@ Send tips to https://paypal.me/UnityVibrationPlugin
 
 # Installation
 
-Copy and paste the entire `Vibration` folder in your Unity3D `Assets` folder or download and import the `Vibration.unitypackage` file.
+The minimal checked Unity Version is 2019.3.* LTS
+
+Open Package Manager and "Add package from git url..." using next string:
+* `https://github.com/BenoitFreslon/Vibration.git`
+
+You also can edit `Packages/manifest.json` manually, just add:
+* `"com.benoitfreslon.vibration": "https://github.com/BenoitFreslon/Vibration.git",`
+
+Or you can simply copy and paste the entire `Vibration` folder to your Unity3D `Assets` folder.
 
 # Use
 
-## Initiatlisation
+## Initialization
 
 Initialize the plugin with this line before using vibrations:
 
@@ -66,9 +74,6 @@ Vibration.Vibrate ( pattern, -1 );
 ## IOS only
 vibration using haptic engine
 
-> Haptic Engine
-
-
 `Vibration.VibrateIOS(ImpactFeedbackStyle.Light);`
 
 `Vibration.VibrateIOS(ImpactFeedbackStyle.Medium);`
@@ -86,4 +91,3 @@ vibration using haptic engine
 `Vibration.VibrateIOS(NotificationFeedbackStyle.Warning);`
 
 `Vibration.VibrateIOS_SelectionChanged();`
-```

--- a/Vibration.asmdef
+++ b/Vibration.asmdef
@@ -1,3 +1,18 @@
 {
-	"name": "Vibration"
+    "name": "Vibration",
+    "rootNamespace": "",
+    "references": [],
+    "includePlatforms": [
+        "Android",
+        "Editor",
+        "iOS"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Vibration.asmdef
+++ b/Vibration.asmdef
@@ -1,0 +1,3 @@
+{
+	"name": "Vibration"
+}

--- a/Vibration.asmdef.meta
+++ b/Vibration.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0c0c8357443d62a4c9e55fe39d3a3e51
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Vibration.meta
+++ b/Vibration.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: de263cf6d06154de79925e3db600168f
+guid: af2a58662a093454d93166d4cc67760e
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Vibration/Plugins/iOS/Vibration/HapticFeedback.mm.meta
+++ b/Vibration/Plugins/iOS/Vibration/HapticFeedback.mm.meta
@@ -1,0 +1,37 @@
+fileFormatVersion: 2
+guid: 077b20d7b7a7dc14aafdb8363888b849
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      tvOS: tvOS
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "com.benoitfreslon.vibration",
+  "author": "Benoit Freslon, AminSojoudi, SH42913",
+  "displayName": "Vibration",
+  "description": "Native free plugin for Unity for iOS and Android. Use custom vibrations on mobile.",
+  "unity": "2019.3",
+  "version": "2023.1.1",
+  "keywords": [],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BenoitFreslon/Vibration"
+  }
+}

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6ae7b7582587a39419e1454a19513673
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Now anyone will be available to add Vibration as git-package to Unity.
For testing you must use `https://github.com/SH42913/Vibration.git#unity-package` instead of `https://github.com/BenoitFreslon/Vibration.git`
It will solve #21