### PR TITLE
the default Vibrate() for webgl was 1000ms, it was too long, I made it 1ms instead (invokes the minimum duration internally, not literally 1 millisecond)

### DIFF
--- a/Vibration/Vibration.cs
+++ b/Vibration/Vibration.cs
@@ -248,20 +248,14 @@ public static class Vibration
     }
 
 
-    public static void Vibrate2 ()
-    {
-            VibrateWebgl ( 1000 );      
-    }
     public static void Vibrate ()
     {
 #if UNITY_ANDROID || UNITY_IOS
-        
         if ( Application.isMobilePlatform ) {
             Handheld.Vibrate ();
         }
-
 #elif UNITY_WEBGL
-        if ( !Application.isEditor ) {
+        if ( Application.isMobilePlatform ) {
             VibrateWebgl ( 1 );      
         }
 #endif

--- a/Vibration/Vibration.cs
+++ b/Vibration/Vibration.cs
@@ -248,6 +248,10 @@ public static class Vibration
     }
 
 
+    public static void Vibrate2 ()
+    {
+            VibrateWebgl ( 1000 );      
+    }
     public static void Vibrate ()
     {
 #if UNITY_ANDROID || UNITY_IOS
@@ -257,8 +261,8 @@ public static class Vibration
         }
 
 #elif UNITY_WEBGL
-        if ( Application.isMobilePlatform ) {
-            VibrateWebgl ( 1000 );      
+        if ( !Application.isEditor ) {
+            VibrateWebgl ( 1 );      
         }
 #endif
     }


### PR DESCRIPTION
The 1000ms duration might seem more like an error than a gameplay feedback, so its probably best to leave the default `Vibrate ()` to something less noticeable. `1ms` invokes the minimum duration, not literally 1 millisecond.